### PR TITLE
Fix missing imports for behat step definitions broken in 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ### Unreleased
 
+### v2.0.1 (2024-12-13)
+
+* Fix missing imports for behat step definitions broken in 2.0.0
+
 ### v2.0.0 (2024-12-13)
 
 * [BREAKING] Use doctrine attributes instead of annotations for entity metadata

--- a/src/BehatContexts/ContentSnippetsContext.php
+++ b/src/BehatContexts/ContentSnippetsContext.php
@@ -10,6 +10,8 @@ namespace Ingenerator\ContentSnippets\BehatContexts;
 use Behat\Gherkin\Node\PyStringNode;
 use Behat\MinkExtension\Context\RawMinkContext;
 use Behat\Step\Given;
+use Behat\Step\Then;
+use Behat\Step\When;
 use Ingenerator\ContentSnippets\Repository\ContentSnippetRepository;
 use PHPUnit\Framework\Assert;
 use function trim;


### PR DESCRIPTION
The commit in ingenerator/content-snippets@70c5fbc switched them from annotations to attributes but didn't import the attribute classes meaning behat could not find them.